### PR TITLE
Fix macOS paths

### DIFF
--- a/share/applications/RabbitRemoteControl.sh
+++ b/share/applications/RabbitRemoteControl.sh
@@ -7,7 +7,15 @@ PRONAME=$(readlink -f $0)
 #获取文件运行的当前目录
 INSTALL_PATH=$(readlink -f $(dirname $(dirname $PRONAME)))
 
+xattr -r -d com.apple.quarantine "$INSTALL_PATH"
+
 echo "INSTALL_PATH:$INSTALL_PATH"
-export LD_LIBRARY_PATH=$INSTALL_PATH/bin:$INSTALL_PATH/lib:$INSTALL_PATH/lib/`uname -m`-linux-gnu:$INSTALL_PATH/plugins/Client:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$INSTALL_PATH/bin:$INSTALL_PATH/lib:$HOMEBREW_PREFIX/lib:$INSTALL_PATH/lib/`uname -m`-linux-gnu:$INSTALL_PATH/plugins/Client:$LD_LIBRARY_PATH
 echo "LD_LIBRARY_PATH:$LD_LIBRARY_PATH"
+export DYLD_LIBRARY_PATH=$INSTALL_PATH/lib
+echo "DYLD_LIBRARY_PATH:$DYLD_LIBRARY_PATH"
+DYLD_FRAMEWORK_PATH=$HOMEBREW_PREFIX/lib
+eval "$(/usr/local/bin/brew shellenv)"
+export DYLD_FRAMEWORK_PATH=$DYLD_FRAMEWORK_PATH:$HOMEBREW_PREFIX/lib
+echo "DYLD_FRAMEWORK_PATH:$DYLD_FRAMEWORK_PATH"
 $INSTALL_PATH/bin/RabbitRemoteControlApp $*


### PR DESCRIPTION
The program does not start on macOS because it's unable to find it's own libraries (DYLD_LIBRARY_PATH) and Qt libraries (DYLD_FRAMEWORK_PATH). Also, the macOS quarantines the program libraries, so it recursively removes the quarantine attributes of the program files for the program to be able to run. I do believe that Qt libraries should be included on macOS binaries the same way they are bundled on Windows builds, because it requires the user installs Qt on their systems to be able to run the macOS build.