### PR TITLE
Copy qtermwidget6 files during build to share

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -255,6 +255,8 @@ if(WITH_QTERMWIDGET)
         list(APPEND PLUGIN_UI_FILES
             Terminal/ParameterTerminalUI.ui
         )
+        file(COPY "${qtermwidget${QT_VERSION_MAJOR}_DIR}/../../../share/"
+            DESTINATION "${CMAKE_BINARY_DIR}/share")
         option(INSTALL_QTERMWIDGET "Install qtermwidget libraries" OFF)
         if(INSTALL_QTERMWIDGET)
             INSTALL_TARGETS(TARGETS qtermwidget${QT_VERSION_MAJOR})


### PR DESCRIPTION
Fixes https://github.com/KangLin/RabbitRemoteControl/issues/65