### PR TITLE
Hides the 'Main menu bar' since it's always visible on macOS

### DIFF
--- a/App/Client/mainwindow.cpp
+++ b/App/Client/mainwindow.cpp
@@ -350,8 +350,12 @@ MainWindow::MainWindow(QWidget *parent)
         ui->actionMain_menu_bar_M->setChecked(m_Parameter.GetMenuBar());
         menuBar()->setVisible(m_Parameter.GetMenuBar());
         ui->actionToolBar_T->setChecked(!ui->toolBar->isHidden());
-        #ifndef Q_OS_MACOS
-        // Hide 'Main menu bar' icon on macOS since it's always visible
+        // macOS: Hide 'Main menu bar' on macOS since it's always visible
+        #ifdef Q_OS_MACOS
+        // Hide 'Main menu bar' on View menu
+        ui->actionMain_menu_bar_M->setVisible(false);
+        #else
+        // Show 'Main menu bar' toolbar icon
         if(!m_Parameter.GetMenuBar())
             ui->toolBar->insertAction(ui->actionTabBar_B,
                                       ui->actionMain_menu_bar_M);

--- a/App/Client/mainwindow.cpp
+++ b/App/Client/mainwindow.cpp
@@ -350,9 +350,12 @@ MainWindow::MainWindow(QWidget *parent)
         ui->actionMain_menu_bar_M->setChecked(m_Parameter.GetMenuBar());
         menuBar()->setVisible(m_Parameter.GetMenuBar());
         ui->actionToolBar_T->setChecked(!ui->toolBar->isHidden());
+        #ifndef Q_OS_MACOS
+        // Hide 'Main menu bar' icon on macOS since it's always visible
         if(!m_Parameter.GetMenuBar())
             ui->toolBar->insertAction(ui->actionTabBar_B,
                                       ui->actionMain_menu_bar_M);
+        #endif
     }
 
     slotEnableSystemTrayIcon();


### PR DESCRIPTION
Hides the 'Main menu bar' since it's always visible on macOS:

<img width="1627" height="643" alt="image" src="https://github.com/user-attachments/assets/866289e6-4a4d-4175-ae0b-a47b373ac276" />
